### PR TITLE
Add paper submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "paper"]
+	path = paper
+	url = https://github.com/alexlyttle/scalable-stellar-inference-paper.git


### PR DESCRIPTION
Adds the corresponding paper as a git submodule. The paper can be managed separately (e.g. in Overleaf), but this allows the adding of plots to the paper from scripts in this repository.